### PR TITLE
Fixed issue with accessing deployed environment variables

### DIFF
--- a/packages/web-app/src/lib/components/map/map.svelte
+++ b/packages/web-app/src/lib/components/map/map.svelte
@@ -265,7 +265,7 @@
 {#if mapType === 'resultList'}
   <div
     id={mapId}
-    class="bg-blue-500/5 w-full h-64 md:h-80 lg:h-96 xl:h-[28rem] 2xl:h-[32rem]"
+    class="bg-blue-500/5 w-full aspect-video"
     data-config={sConfig}
     data-lang={mapLang}
   ></div>

--- a/packages/web-app/src/lib/components/record/i18n/en/translations.json
+++ b/packages/web-app/src/lib/components/record/i18n/en/translations.json
@@ -33,7 +33,7 @@
   "resourcesNotAvailable": "The data resources for this record are unavailable.",
   "role": "Role",
   "selectCategory": "Select Category",
-  "similarProducts": "Similar Products",
+  "similarProducts": "Related Products",
   "sources": "Source(s) and Citation",
   "south": "South",
   "spatialRepresentation": "Spatial Representation",

--- a/packages/web-app/src/lib/components/record/i18n/fr/translations.json
+++ b/packages/web-app/src/lib/components/record/i18n/fr/translations.json
@@ -33,7 +33,7 @@
   "resourcesNotAvailable": "Les ressources de données pour cet enregistrement ne sont pas disponibles.",
   "role": "Rôle",
   "selectCategory": "Sélectionnez une catégorie",
-  "similarProducts": "Produits similaires",
+  "similarProducts": "Produits associés",
   "sources": "Source(s) et Référence",
   "south": "Sud",
   "spatialRepresentation": "Représentation Spatiale",

--- a/packages/web-app/src/lib/components/record/similar-products.svelte
+++ b/packages/web-app/src/lib/components/record/similar-products.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
 
   const translations = $page.data.t;
-  const similarProductsText = translations?.similarProducts ? translations["similarProducts"] : "Similar Products";
+  const similarProductsText = translations?.similarProducts ? translations["similarProducts"] : "Related Products";
 
   const data = $page.data;
   const lang = data.lang;
@@ -18,8 +18,8 @@
   <ul class="flex flex-col space-y-4 list-outside py-2 list-none sm:list-disc sm:ml-[1.125rem]">
     {#each similarProducts as product}
       <li data-sveltekit-reload>
-        <a class="font-custom-style-body-2" href={urlPrefix + product.id}>
-          {lang == 'fr-ca' ? product.description_fr : product.description_en}
+        <a class="font-custom-style-body-2" href={urlPrefix + product.features_properties_id}>
+          {lang == 'fr-ca' ? product.features_properties_title_fr : product.features_properties_title_en}
         </a>
       </li>
     {/each}

--- a/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
+++ b/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
@@ -22,7 +22,7 @@ export const load: PageServerLoad = async ({ fetch, params, url, cookies }) => {
 	// @ts-ignore
 	const fetchRelated = async (id) => {
 		try {
-			const collectionsResponse = await fetch(`https://geocore.api.geo.ca/id/v2?id=${id}&lang=${lang}`);
+			const collectionsResponse = await fetch(`${GEOCORE_API_DOMAIN}/id/v2?id=${id}&lang=${lang}`);
 			const parsedCollectionsResponse = await collectionsResponse.json();
 			const related = parsedCollectionsResponse?.body?.Items?.[0]?.similarity ?? [];
 			return related;
@@ -36,13 +36,13 @@ export const load: PageServerLoad = async ({ fetch, params, url, cookies }) => {
 		let parsedAnalyticResponse;
 		try {
 			const analyticResponse = await fetch(
-				`https://geocore.api.geo.ca/analytics/10?uuid=${id}&lang=${lang}`
+				`${GEOCORE_API_DOMAIN}/analytics/10?uuid=${id}&lang=${lang}`
 			);
 			parsedAnalyticResponse = JSON.parse(await analyticResponse.json());
 		} catch (e) {
 			console.error(
 				'error fetching analytics from:',
-				`https://geocore.api.geo.ca/analytics/10?uuid=${id}&lang=${lang}\nerror message:`,
+				`${GEOCORE_API_DOMAIN}/analytics/10?uuid=${id}&lang=${lang}\nerror message:`,
 				e
 			);
 		}

--- a/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
+++ b/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
@@ -22,22 +22,9 @@ export const load: PageServerLoad = async ({ fetch, params, url, cookies }) => {
 	// @ts-ignore
 	const fetchRelated = async (id) => {
 		try {
-			const collectionsResponse = await fetch(`${GEOCORE_API_DOMAIN}/collections?id=${id}`);
+			const collectionsResponse = await fetch(`https://geocore.api.geo.ca/id/v2?id=${id}&lang=${lang}`);
 			const parsedCollectionsResponse = await collectionsResponse.json();
-			const related = [];
-			if (parsedCollectionsResponse.parent) {
-				related.push({ ...parsedCollectionsResponse.parent, ...{ type: 'parent' } });
-			}
-			if (parsedCollectionsResponse.sibling_count > 0) {
-				parsedCollectionsResponse.sibling.forEach((s) => {
-					related.push({ ...s, ...{ type: 'member' } });
-				});
-			}
-			if (parsedCollectionsResponse.child_count > 0) {
-				parsedCollectionsResponse.child.forEach((s) => {
-					related.push({ ...s, ...{ type: 'member' } });
-				});
-			}
+			const related = parsedCollectionsResponse?.body?.Items?.[0]?.similarity ?? [];
 			return related;
 		} catch (e) {
 			console.error('Error fetching related items:', e);
@@ -49,13 +36,13 @@ export const load: PageServerLoad = async ({ fetch, params, url, cookies }) => {
 		let parsedAnalyticResponse;
 		try {
 			const analyticResponse = await fetch(
-				`${GEOCORE_API_DOMAIN}/analytics/10?uuid=${id}&lang=${lang}`
+				`https://geocore.api.geo.ca/analytics/10?uuid=${id}&lang=${lang}`
 			);
 			parsedAnalyticResponse = JSON.parse(await analyticResponse.json());
 		} catch (e) {
 			console.error(
 				'error fetching analytics from:',
-				`${GEOCORE_API_DOMAIN}/analytics/10?uuid=${id}&lang=${lang}\nerror message:`,
+				`https://geocore.api.geo.ca/analytics/10?uuid=${id}&lang=${lang}\nerror message:`,
 				e
 			);
 		}

--- a/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
+++ b/packages/web-app/src/routes/[lang]/map-browser/record/[uuid]/+page.server.ts
@@ -5,9 +5,14 @@ import frLabels from '$lib/components/record/i18n/fr/translations.json';
 import { error } from '@sveltejs/kit';
 import { parseText } from '$lib/utils/parse-text.ts';
 
-const GEOCORE_API_DOMAIN = process.env.GEOCORE_API_DOMAIN;
-
 export const load: PageServerLoad = async ({ fetch, params, url, cookies }) => {
+    // The "sst/node/config" package dynamically binds resources at runtime.
+    // Importing it at the top level would cause build-time errors because SST resources
+    // are not available during the build process. To avoid this, we import it inside
+    // the `load()` function so it's only accessed when the server is running.
+    const config = await import("sst/node/config");
+	const GEOCORE_API_DOMAIN = config.Config.GEOCORE_API_DOMAIN;
+
 	const lang = params.lang === 'en-ca' ? 'en' : 'fr';
 
 	let record;


### PR DESCRIPTION
This fixes a bug where the GEOCORE_API_DOMAIN environment variable was not working in the deployed version of the app. Instead of an environment variable, it is now a secret.

Note: to run locally, the secret needs to be set with this command:

npx sst secrets set --stage your-stage-name GEOCORE_API_DOMAIN https://geocore.api.geo.ca

It also updates the url used to query related products and a small css fix.