### PR TITLE
Replaceing loading mask with loading skeleton on search results list

### DIFF
--- a/packages/web-app/src/lib/components/footer/i18n/en/legal.json
+++ b/packages/web-app/src/lib/components/footer/i18n/en/legal.json
@@ -2,7 +2,7 @@
   "ccmeo": "Canada Centre for Mapping and Earth Observation",
   "cdgi": "GEO.ca is part of the",
   "cdgiAcronym": "(CGDI)",
-  "cdgiLink": "href='https://natural-resources.canada.ca/science-and-data/science-and-research/geomatics/canadas-spatial-data-infrastructure/10783",
+  "cdgiLink": "https://natural-resources.canada.ca/science-and-data/science-and-research/geomatics/canadas-spatial-data-infrastructure/10783",
   "cdgiLinkText": "Canadian Geospatial Data Infrastructure",
   "contactUs": "Contact Us",
   "copyright": "Powered by GEO.ca, Copyright © 2025",

--- a/packages/web-app/src/lib/components/leaving-notice/leaving-notice.svelte
+++ b/packages/web-app/src/lib/components/leaving-notice/leaving-notice.svelte
@@ -18,7 +18,7 @@
 
 <div
   class="fixed top-0 z-[100050] flex items-center justify-center
-    w-full h-screen bg-custom-5/80 text-7xl"
+    w-full h-screen bg-custom-5/80 text-3xl md:text-7xl"
   style="text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.6);"
 >
   {message}<span class='w-3'>{dots}</span>

--- a/packages/web-app/src/lib/components/leaving-notice/leaving-notice.svelte
+++ b/packages/web-app/src/lib/components/leaving-notice/leaving-notice.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { onDestroy } from 'svelte';
+  import { page } from '$app/stores';
+
+  const lang = $page.data.lang;
+  const message = lang == 'fr-ca' ? 'Vous quittez geo.ca' : 'Leaving geo.ca';
+
+  let dots = '';
+  let interval;
+
+  // Cycle dots every 300ms
+  interval = setInterval(() => {
+    dots = dots.length < 3 ? dots + '.' : '';
+  }, 300);
+
+  onDestroy(() => clearInterval(interval));
+</script>
+
+<div
+  class="fixed top-0 z-[100050] flex items-center justify-center
+    w-full h-screen bg-custom-5/80 text-7xl"
+  style="text-shadow: 2px 2px 6px rgba(0, 0, 0, 0.6);"
+>
+  {message}<span class='w-3'>{dots}</span>
+</div>

--- a/packages/web-app/src/lib/components/loading-mask/result-list-skeleton.svelte
+++ b/packages/web-app/src/lib/components/loading-mask/result-list-skeleton.svelte
@@ -26,7 +26,7 @@
           </div>
           <!-- Expand button placeholder -->
           <div class="col-span-1 col-start-12 self-center">
-            <div class="mt-1 mr-3 h-6 md:h-9 w-6 md:w-9 div-fill" />
+            <div class="mt-1 mr-3 h-6 md:h-9 w-6 md:w-9 div-fill"></div>
           </div>
         </div>
       </div>

--- a/packages/web-app/src/lib/components/loading-mask/result-list-skeleton.svelte
+++ b/packages/web-app/src/lib/components/loading-mask/result-list-skeleton.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  interface Props {numRecords: number;}
+  let { numRecords = 10 }: Props = $props();
+</script>
+
+<!-- Note: the z-index needs to be 100000 because the loading mask on the geoview maps are 99999 -->
+<div class="z-[100000] relative flex flex-col top-0 right-0 w-full h-full min-h-80 bg-custom-5 space-y-7">
+  <!-- Header -->
+  <div class="flex flex-col md:flex-row rounded-sm gap-4">
+    <!-- record stats placeholder -->
+    <div class="h-[1.875rem] w-full max-w-[28rem] div-fill"></div>
+    <!-- sort button placeholder -->
+    <div class="h-11 w-full max-w-40 md:ml-auto div-fill"></div>
+  </div>
+  {#each Array(numRecords) as _, index}
+    <!-- accordion placeholder -->
+    <div class="px-5 py-4 bg-custom-1 rounded-sm">
+      <div>
+        <div class="grid grid-cols-12 w-full h-full text-left">
+          <!-- Record text placeholder-->
+          <div class="col-span-10">
+            <!-- record title placeholder -->
+            <div class="h-[1.375rem] div-fill"></div>
+            <!-- record description placeholder -->
+            <div class="h-[3.25rem] mt-1 div-fill-light"></div>
+          </div>
+          <!-- Expand button placeholder -->
+          <div class="col-span-1 col-start-12 self-center">
+            <div class="mt-1 mr-3 h-6 md:h-9 w-6 md:w-9 div-fill" />
+          </div>
+        </div>
+      </div>
+    </div>
+  {/each}
+  <div class="div-fill h-10 max-w-72 w-full ml-auto"></div>
+</div>
+
+<style>
+  .div-fill {
+    @apply animate-pulse;
+    @apply bg-custom-9;
+    @apply rounded-md;
+  }
+
+  .div-fill-light {
+    @apply animate-pulse;
+    @apply bg-custom-6;
+    @apply rounded-md;
+  }
+</style>

--- a/packages/web-app/src/lib/components/map/map.svelte
+++ b/packages/web-app/src/lib/components/map/map.svelte
@@ -253,7 +253,7 @@
       // Add bounding box when no map is available
       if (!geoviewLayerConfig) {
         let bbox = getBbox(coordinates);
-        cgpv.api.maps[mapId]?.layer.geometry.addPolygon(
+        cgpv.api.getMapViewer(mapId)?.layer.geometry.addPolygon(
           [bbox],
           {
             style: {

--- a/packages/web-app/src/lib/components/record/i18n/en/translations.json
+++ b/packages/web-app/src/lib/components/record/i18n/en/translations.json
@@ -30,6 +30,7 @@
   "organization": "Organization",
   "projection": "Projection",
   "relatedProducts": "Related products",
+  "relatedProductsNotAvailable": "The related products for this record are unavailable.",
   "resources": "Resources",
   "resourcesNotAvailable": "The data resources for this record are unavailable.",
   "role": "Role",

--- a/packages/web-app/src/lib/components/record/i18n/fr/translations.json
+++ b/packages/web-app/src/lib/components/record/i18n/fr/translations.json
@@ -30,6 +30,7 @@
   "organization": "Organisation",
   "projection": "Projection",
   "relatedProducts": "Produits connexes",
+  "relatedProductsNotAvailable": "Les produits connexes pour cet enregistrement ne sont pas disponibles.",
   "resources": "Ressources",
   "resourcesNotAvailable": "Les ressources de données pour cet enregistrement ne sont pas disponibles.",
   "role": "Rôle",

--- a/packages/web-app/src/lib/components/record/tabbed/related-products.svelte
+++ b/packages/web-app/src/lib/components/record/tabbed/related-products.svelte
@@ -11,6 +11,9 @@
 
   /******************* Translations *******************/
   const translations = $page.data.t;
+  const relatedProductsNotAvailable = translations?.relatedProductsNotAvailable ?
+    translations["relatedProductsNotAvailable"] :
+    "The related products for this record are unavailable.";
 
   // Row labels
   const nameText = translations?.name ? translations["name"] : "Name";
@@ -47,22 +50,27 @@
     currentPage = event;
   }
 </script>
-
-<SortableTable
-  tableContent={tableDataArray}
-  tableLabels={tableLabels}
-  clickableRows={true}
-  paginated={true}
-  currentPage={currentPage}
-  itemsPerPage={itemsPerPage}
-/>
-{#if tableDataArray.length > itemsPerPage}
-  <div class="flex justify-end w-full">
-    <Pagination
-      totalItems={total}
-      itemsPerPage={itemsPerPage}
-      bind:currentPage={currentPage}
-      pageChange={changePage}
-    />
+{#if tableDataArray.length == 0}
+  <div>
+    {relatedProductsNotAvailable}
   </div>
+{:else}
+  <SortableTable
+    tableContent={tableDataArray}
+    tableLabels={tableLabels}
+    clickableRows={true}
+    paginated={true}
+    currentPage={currentPage}
+    itemsPerPage={itemsPerPage}
+  />
+  {#if tableDataArray.length > itemsPerPage}
+    <div class="flex justify-end w-full">
+      <Pagination
+        totalItems={total}
+        itemsPerPage={itemsPerPage}
+        bind:currentPage={currentPage}
+        pageChange={changePage}
+      />
+    </div>
+  {/if}
 {/if}

--- a/packages/web-app/src/lib/components/search-results/result-list.svelte
+++ b/packages/web-app/src/lib/components/search-results/result-list.svelte
@@ -147,99 +147,99 @@
   {#if $navigating}
     <ResultListSkeleton numRecords={results.length} />
   {:else}
-    <!-- Header -->
-    <div class="flex flex-col md:flex-row justify-between flex-wrap gap-y-4">
-      <p class="font-custom-style-body-6">
-        {pageMessage}
-      </p>
-      <div class="flex flex-row gap-3 md:gap-5">
-        <div>
-          <SelectCustomized
-            selectType='resultList'
-            optionsData={sortBySelectData}
-            bind:selected={selected}
-            selectedChange={changeSort}
-          />
-        </div>
-        {#if userId}
-          <!-- TODO: Add a method for this button -->
-          <button class="button-3">{saveSearchParamsText}</button>
-        {/if}
+  <!-- Header -->
+  <div class="flex flex-col md:flex-row justify-between flex-wrap gap-y-4">
+    <p class="font-custom-style-body-6">
+      {pageMessage}
+    </p>
+    <div class="flex flex-row gap-3 md:gap-5">
+      <div>
+        <SelectCustomized
+          selectType='resultList'
+          optionsData={sortBySelectData}
+          bind:selected={selected}
+          selectedChange={changeSort}
+        />
       </div>
+      {#if userId}
+        <!-- TODO: Add a method for this button -->
+        <button class="button-3">{saveSearchParamsText}</button>
+      {/if}
     </div>
-    <!-- List -->
-    {#each results as result, index}
-      <div class="bg-custom-1 px-5 py-4">
-        <Accordion bind:this={accordionComponents[index]}>
-          {#snippet accordionTitle()}
-            <div>
-              <a
-                href={hrefPrefix + result.id}
-                class="uppercase underline font-custom-style-header-2"
-              >
-                {result.title}
-              </a>
-              <div class="line-clamp-2 pt-1">
-                <!-- Remove new line characters -->
-                {result.description.replaceAll('\\n', '')}
-              </div>
+  </div>
+  <!-- List -->
+  {#each results as result, index}
+    <div class="bg-custom-1 px-5 py-4">
+      <Accordion bind:this={accordionComponents[index]}>
+        {#snippet accordionTitle()}
+          <div>
+            <a
+              href={hrefPrefix + result.id}
+              class="uppercase underline font-custom-style-header-2"
+            >
+              {result.title}
+            </a>
+            <div class="line-clamp-2 pt-1">
+              <!-- Remove new line characters -->
+              {result.description.replaceAll('\\n', '')}
             </div>
-          {/snippet}
-          {#snippet accordionContent()}
-            <div  class="mt-5">
+          </div>
+        {/snippet}
+        {#snippet accordionContent()}
+          <div  class="mt-5">
 
-              <!-- Record Details -->
-              <div class="mb-5">
-                <p>
-                  <span class="font-semibold">{organizationText}: </span>
-                  {lang == 'fr' ?
-                      result.contact[0].organisation.fr.replaceAll(';', '; ') :
-                      result.contact[0].organisation.en.replaceAll(';', '; ')}
-                </p>
-                <p class="mt-2">
-                  <span class="font-semibold">{formatText}: </span>
-                  {#each getFormats(result) as format, i}
-                    <span class="text-sm bg-custom-16/15 py-0.5 px-2 mt-1 mr-2 rounded inline-block">{format}</span>
-                  {/each}
-                </p>
+            <!-- Record Details -->
+            <div class="mb-5">
+              <p>
+                <span class="font-semibold">{organizationText}: </span>
+                {lang == 'fr' ?
+                    result.contact[0].organisation.fr.replaceAll(';', '; ') :
+                    result.contact[0].organisation.en.replaceAll(';', '; ')}
+              </p>
+              <p class="mt-2">
+                <span class="font-semibold">{formatText}: </span>
+                {#each getFormats(result) as format, i}
+                  <span class="text-sm bg-custom-16/15 py-0.5 px-2 mt-1 mr-2 rounded inline-block">{format}</span>
+                {/each}
+              </p>
+            </div>
+
+            <!-- Map -->
+            <!-- Note: We will only show a map for screens larger than 640px -->
+            {#if result.coordinates}
+              <div class="hidden sm:flex">
+                <Map
+                  coordinates={result.coordinates} id={result.id}
+                  dynamic={true} mapType={mapType} footer={false}
+                />
               </div>
-
-              <!-- Map -->
-              <!-- Note: We will only show a map for screens larger than 640px -->
-              {#if result.coordinates}
-                <div class="hidden sm:flex">
-                  <Map
-                    coordinates={result.coordinates} id={result.id}
-                    dynamic={true} mapType={mapType} footer={false}
-                  />
-                </div>
-                <div class="sm:hidden">
-                  <p class="md:mx-0">
-                    {windowTooSmall}
-                  </p>
-                  <div class="mt-5 bg-[url('/map-not-available.png')] bg-cover max-w-full h-60">
-                    <div class="bg-black/35 w-full h-full flex items-center justify-center">
-                      <NotVisible classes="text-custom-1 h-32"/>
-                    </div>
+              <div class="sm:hidden">
+                <p class="md:mx-0">
+                  {windowTooSmall}
+                </p>
+                <div class="mt-5 bg-[url('/map-not-available.png')] bg-cover max-w-full h-60">
+                  <div class="bg-black/35 w-full h-full flex items-center justify-center">
+                    <NotVisible classes="text-custom-1 h-32"/>
                   </div>
                 </div>
-              {:else}
-                {mapNotAvailableText}
-              {/if}
+              </div>
+            {:else}
+              {mapNotAvailableText}
+            {/if}
 
-            </div>
-          {/snippet}
-        </Accordion>
-      </div>
-    {/each}
-    <!-- Pagination -->
-    <div class="flex justify-end w-full">
-      <Pagination
-        totalItems={total}
-        {itemsPerPage}
-        bind:currentPage={currentPage}
-        pageChange={changePage}
-      />
+          </div>
+        {/snippet}
+      </Accordion>
     </div>
+  {/each}
+  <!-- Pagination -->
+  <div class="flex justify-end w-full">
+    <Pagination
+      totalItems={total}
+      {itemsPerPage}
+      bind:currentPage={currentPage}
+      pageChange={changePage}
+    />
+  </div>
   {/if}
 </Card>

--- a/packages/web-app/src/lib/components/search-results/result-list.svelte
+++ b/packages/web-app/src/lib/components/search-results/result-list.svelte
@@ -4,7 +4,7 @@
   import { tick } from 'svelte';
   import Accordion from '$lib/components/accordion/accordion.svelte';
   import Card from '$lib/components/card/card.svelte';
-  import LoadingMask from '$lib/components/loading-mask/loading-mask.svelte';
+  import ResultListSkeleton from '$lib/components/loading-mask/result-list-skeleton.svelte';
   import Map from '$lib/components/map/map.svelte';
   import Pagination from '$lib/components/pagination/pagination.svelte';
   import SelectCustomized from '$lib/components/select-customized/select-customized.svelte';
@@ -145,100 +145,101 @@
 
 <Card>
   {#if $navigating}
-    <LoadingMask classes="absolute top-0 right-0 pt-28 min-h-80"/>
-  {/if}
-  <!-- Header -->
-  <div class="flex flex-col md:flex-row justify-between flex-wrap gap-y-4">
-    <p class="font-custom-style-body-6">
-      {pageMessage}
-    </p>
-    <div class="flex flex-row gap-3 md:gap-5">
-      <div>
-        <SelectCustomized
-          selectType='resultList'
-          optionsData={sortBySelectData}
-          bind:selected={selected}
-          selectedChange={changeSort}
-        />
+    <ResultListSkeleton numRecords={results.length} />
+  {:else}
+    <!-- Header -->
+    <div class="flex flex-col md:flex-row justify-between flex-wrap gap-y-4">
+      <p class="font-custom-style-body-6">
+        {pageMessage}
+      </p>
+      <div class="flex flex-row gap-3 md:gap-5">
+        <div>
+          <SelectCustomized
+            selectType='resultList'
+            optionsData={sortBySelectData}
+            bind:selected={selected}
+            selectedChange={changeSort}
+          />
+        </div>
+        {#if userId}
+          <!-- TODO: Add a method for this button -->
+          <button class="button-3">{saveSearchParamsText}</button>
+        {/if}
       </div>
-      {#if userId}
-        <!-- TODO: Add a method for this button -->
-        <button class="button-3">{saveSearchParamsText}</button>
-      {/if}
     </div>
-  </div>
-  <!-- List -->
-  {#each results as result, index}
-    <div class="bg-custom-1 px-5 py-4">
-      <Accordion bind:this={accordionComponents[index]}>
-        {#snippet accordionTitle()}
-          <div>
-            <a
-              href={hrefPrefix + result.id}
-              class="uppercase underline font-custom-style-header-2"
-            >
-              {result.title}
-            </a>
-            <div class="line-clamp-2 pt-1">
-              <!-- Remove new line characters -->
-              {result.description.replaceAll('\\n', '')}
-            </div>
-          </div>
-        {/snippet}
-        {#snippet accordionContent()}
-          <div  class="mt-5">
-
-            <!-- Record Details -->
-            <div class="mb-5">
-              <p>
-                <span class="font-semibold">{organizationText}: </span>
-                {lang == 'fr' ?
-                    result.contact[0].organisation.fr.replaceAll(';', '; ') :
-                    result.contact[0].organisation.en.replaceAll(';', '; ')}
-              </p>
-              <p class="mt-2">
-                <span class="font-semibold">{formatText}: </span>
-                {#each getFormats(result) as format, i}
-                  <span class="text-sm bg-custom-16/15 py-0.5 px-2 mt-1 mr-2 rounded inline-block">{format}</span>
-                {/each}
-              </p>
-            </div>
-
-            <!-- Map -->
-            <!-- Note: We will only show a map for screens larger than 640px -->
-            {#if result.coordinates}
-              <div class="hidden sm:flex">
-                <Map
-                  coordinates={result.coordinates} id={result.id}
-                  dynamic={true} mapType={mapType} footer={false}
-                />
+    <!-- List -->
+    {#each results as result, index}
+      <div class="bg-custom-1 px-5 py-4">
+        <Accordion bind:this={accordionComponents[index]}>
+          {#snippet accordionTitle()}
+            <div>
+              <a
+                href={hrefPrefix + result.id}
+                class="uppercase underline font-custom-style-header-2"
+              >
+                {result.title}
+              </a>
+              <div class="line-clamp-2 pt-1">
+                <!-- Remove new line characters -->
+                {result.description.replaceAll('\\n', '')}
               </div>
-              <div class="sm:hidden">
-                <p class="md:mx-0">
-                  {windowTooSmall}
+            </div>
+          {/snippet}
+          {#snippet accordionContent()}
+            <div  class="mt-5">
+
+              <!-- Record Details -->
+              <div class="mb-5">
+                <p>
+                  <span class="font-semibold">{organizationText}: </span>
+                  {lang == 'fr' ?
+                      result.contact[0].organisation.fr.replaceAll(';', '; ') :
+                      result.contact[0].organisation.en.replaceAll(';', '; ')}
                 </p>
-                <div class="mt-5 bg-[url('/map-not-available.png')] bg-cover max-w-full h-60">
-                  <div class="bg-black/35 w-full h-full flex items-center justify-center">
-                    <NotVisible classes="text-custom-1 h-32"/>
+                <p class="mt-2">
+                  <span class="font-semibold">{formatText}: </span>
+                  {#each getFormats(result) as format, i}
+                    <span class="text-sm bg-custom-16/15 py-0.5 px-2 mt-1 mr-2 rounded inline-block">{format}</span>
+                  {/each}
+                </p>
+              </div>
+
+              <!-- Map -->
+              <!-- Note: We will only show a map for screens larger than 640px -->
+              {#if result.coordinates}
+                <div class="hidden sm:flex">
+                  <Map
+                    coordinates={result.coordinates} id={result.id}
+                    dynamic={true} mapType={mapType} footer={false}
+                  />
+                </div>
+                <div class="sm:hidden">
+                  <p class="md:mx-0">
+                    {windowTooSmall}
+                  </p>
+                  <div class="mt-5 bg-[url('/map-not-available.png')] bg-cover max-w-full h-60">
+                    <div class="bg-black/35 w-full h-full flex items-center justify-center">
+                      <NotVisible classes="text-custom-1 h-32"/>
+                    </div>
                   </div>
                 </div>
-              </div>
-            {:else}
-              {mapNotAvailableText}
-            {/if}
+              {:else}
+                {mapNotAvailableText}
+              {/if}
 
-          </div>
-        {/snippet}
-      </Accordion>
+            </div>
+          {/snippet}
+        </Accordion>
+      </div>
+    {/each}
+    <!-- Pagination -->
+    <div class="flex justify-end w-full">
+      <Pagination
+        totalItems={total}
+        {itemsPerPage}
+        bind:currentPage={currentPage}
+        pageChange={changePage}
+      />
     </div>
-  {/each}
-  <!-- Pagination -->
-  <div class="flex justify-end w-full">
-    <Pagination
-      totalItems={total}
-      {itemsPerPage}
-      bind:currentPage={currentPage}
-      pageChange={changePage}
-    />
-  </div>
+  {/if}
 </Card>

--- a/packages/web-app/src/lib/components/search-results/result-list.svelte
+++ b/packages/web-app/src/lib/components/search-results/result-list.svelte
@@ -177,11 +177,14 @@
               href={hrefPrefix + result.id}
               class="uppercase underline font-custom-style-header-2"
             >
-              {result.title}
+              {lang == 'fr' ? result.title_fr : result.title_en}
             </a>
             <div class="line-clamp-2 pt-1">
               <!-- Remove new line characters -->
-              {result.description.replaceAll('\\n', '')}
+              {lang == 'fr' ?
+                result.description_fr.replaceAll('\\n', '') :
+                result.description_en.replaceAll('\\n', '')
+              }
             </div>
           </div>
         {/snippet}

--- a/packages/web-app/src/routes/[lang]/+layout.svelte
+++ b/packages/web-app/src/routes/[lang]/+layout.svelte
@@ -44,7 +44,7 @@
         setTimeout(() => {
           showLeavingSitePopup = false;
           window.location.href = href;
-        }, 1800);
+        }, 2000);
       }
     };
 

--- a/packages/web-app/src/routes/[lang]/+layout.svelte
+++ b/packages/web-app/src/routes/[lang]/+layout.svelte
@@ -32,7 +32,7 @@
 
       const href = anchor.href;
       const isExternal = href
-        && !href.startsWith($page.url.origin)
+        && !href.includes($page.url.host)
         && !href.includes('geo.ca')
         && !href.startsWith('mailto');
 

--- a/packages/web-app/src/routes/[lang]/+layout.svelte
+++ b/packages/web-app/src/routes/[lang]/+layout.svelte
@@ -15,7 +15,6 @@
 
   let { children }: Props = $props();
   let showLeavingSitePopup = $state(false);
-
   const lang = $page.data.lang?.slice(0, 2) ?? 'en';
 
   // Set the language of the page. This needs to be done using onMount to
@@ -43,8 +42,9 @@
         // delay navigation to allow for users to read the message
         event.preventDefault();
         setTimeout(() => {
+          showLeavingSitePopup = false;
           window.location.href = href;
-        }, 1000);
+        }, 1800);
       }
     };
 

--- a/packages/web-app/src/routes/[lang]/+layout.svelte
+++ b/packages/web-app/src/routes/[lang]/+layout.svelte
@@ -7,11 +7,14 @@
   import Footer from '$lib/components/footer/footer.svelte';
   import Feedback from '$lib/components/feedback/feedback.svelte';
   import Breadcrumbs from '$lib/components/breadcrumbs/breadcrumbs.svelte';
+  import LeavingNotice from '$lib/components/leaving-notice/leaving-notice.svelte';
+
   interface Props {
     children?: import('svelte').Snippet;
   }
 
   let { children }: Props = $props();
+  let showLeavingSitePopup = $state(false);
 
   const lang = $page.data.lang?.slice(0, 2) ?? 'en';
 
@@ -20,6 +23,33 @@
   // Assigning the language using <svelte:head> instead sometimes caused errors
   onMount(() => {
     document.documentElement.lang = lang;
+
+    // When the user clicks on an external link, indicate to the user that they are leaving
+    const handleClick = (event) => {
+      const anchor = event.target.closest('a');
+      if (!anchor) {
+        return;
+      }
+
+      const href = anchor.href;
+      const isExternal = href
+        && !href.startsWith($page.url.origin)
+        && !href.includes('geo.ca')
+        && !href.startsWith('mailto');
+
+      if (isExternal) {
+        showLeavingSitePopup = true;
+
+        // delay navigation to allow for users to read the message
+        event.preventDefault();
+        setTimeout(() => {
+          window.location.href = href;
+        }, 1000);
+      }
+    };
+
+    window.addEventListener('click', handleClick);
+    return () => window.removeEventListener('click', handleClick);
   });
 </script>
 
@@ -35,3 +65,7 @@
   <Feedback />
 </div>
 <Footer />
+
+{#if showLeavingSitePopup}
+  <LeavingNotice />
+{/if}

--- a/packages/web-app/src/routes/[lang]/map-browser/+page.server.ts
+++ b/packages/web-app/src/routes/[lang]/map-browser/+page.server.ts
@@ -157,7 +157,7 @@ function mapSemanticSearchResults(searchParams, lang) {
 	  west + "," + south + "," + east + "," + north : "";
 	let ret = {
 		// Revisit which search method is better after user testing
-	    method: 'HybridSearch', // 'SemanticSearch',
+	    method: 'SemanticSearch', // 'HybridSearch',
 	    q: getKeyword(searchParams),
 	    bbox: bbox,
 	    relation: searchParams.get('relation') ?? 'intersects',


### PR DESCRIPTION
This adds a loading skeleton component for the search results list, replacing the old mask. The mask will now only be used when switching between pages (e.g., going from search results to a record page).